### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2178,6 +2178,10 @@
               <goals>
                 <goal>test</goal>
               </goals>
+              <configuration>
+                <!-- Ignore MySQLIntegrationSuite.scala from Docker Integration since it downloads x86 specific image -->
+                <wildcardSuites>!MySQLIntegrationSuite</wildcardSuites>
+              </configuration>
             </execution>
           </executions>
         </plugin>


### PR DESCRIPTION
The pom.xml file is updated to exclude MySQLIntegrationSuite.scala suite .It creates and tries to start a docker container by downloading the 'mysql:5.7.9' image which is meant for the amd64 architecture. 

